### PR TITLE
Úprava textu na stránce o psychickém zdraví

### DIFF
--- a/juniorguru/mkdocs/docs/handbook/mental-health.md
+++ b/juniorguru/mkdocs/docs/handbook/mental-health.md
@@ -70,7 +70,7 @@ Pokud po pár sezeních necítíš významné zlepšení, nevěš hlavu, **chce 
 
 ### Klinický psycholog
 
-Absolventi doktorského studia v oboru klinické psychologie mohou poskytovat psychoterapii a zhodnocovat tvůj psychický stav (psychodiagnostika). Sice ti **vše uhradí pojišťovna**, ale protože klinických psychologů není mnoho, tak mívají plno, nebo nabízejí dlouhé objednací lhůty.
+Absolventi postgraduálního specializačního vzdělávání v oboru klinické psychologie mohou poskytovat psychoterapii a zhodnocovat tvůj psychický stav (psychodiagnostika). Sice ti **vše uhradí pojišťovna**, ale protože klinických psychologů není mnoho, tak mívají plno, nebo nabízejí dlouhé objednací lhůty.
 
 ### Psychoterapeut na přímou platbu
 


### PR DESCRIPTION
Akorát teď je ta věta takhle:

> Absolventi postgraduálního specializačního vzdělávání v oboru klinické psychologie mohou poskytovat psychoterapii a zhodnocovat tvůj psychický stav (psychodiagnostika).

A mě to přijde, jako smrtelníkovi mimo obor, jako zcela nesrozumitelná směs termitů, asi jako když jsem si dnes na Wikipedii četl, že „andragogika osciluje mezi interdisciplinaritou a transdisciplinaritou“, pak se mi zamotala hlava a další slova mozek už vůbec nevnímal. Jako hotfix může být, aby tam nebyly nepravdy, ale rád bych do budoucna ten text přiblížil laikům a k tomu, aby se dal číst i bez VŠ vzdělání nebo bez 100% soustředění.