### PR TITLE
Revert "Add utm params to CoreSkill URL"

### DIFF
--- a/juniorguru/data/course_providers/coreskill.yml
+++ b/juniorguru/data/course_providers/coreskill.yml
@@ -1,2 +1,2 @@
 name: CoreSkill
-url: https://coreskill.tech/?utm_source=junior.guru&utm_medium=web&utm_campaign=catalog
+url: https://coreskill.tech/


### PR DESCRIPTION
Reverts honzajavorek/junior.guru#1145

```
[juniorguru.cli.check_docs] ERROR: Broken static file! /courses/coreskill/ links to public/static/images/screenshots/coreskill-tech-utm-source-junior-guru-utm-medium-web-utm-campaign-catalog.jpg
[juniorguru.cli.check_docs] ERROR: Broken static file! /courses/ links to public/static/images/screenshots/coreskill-tech-utm-source-junior-guru-utm-medium-web-utm-campaign-catalog.jpg
```

Opravím po dovolené a pak vrátím utmka zpět do kódu, fyi @benabraham 